### PR TITLE
Remove HTML elements from site.title to fix RSS feed

### DIFF
--- a/_includes/feed-footer.html
+++ b/_includes/feed-footer.html
@@ -1,1 +1,1 @@
-&lt;p&gt;&lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;{{ post.title | xml_escape }}&lt;/a&gt; was originally published by {{ site.owner.name }} at &lt;a href=&quot;{{ site.url }}&quot;&gt;{{ site.title }}&lt;/a&gt; on {{ post.date | date: "%B %d, %Y" }}.&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;{{ post.title | xml_escape }}&lt;/a&gt; was originally published by {{ site.owner.name }} at &lt;a href=&quot;{{ site.url }}&quot;&gt;{{ site.title | strip_html }}&lt;/a&gt; on {{ post.date | date: "%B %d, %Y" }}.&lt;/p&gt;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.title }}</title>
+<title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.title | strip_html }}</title>
 {% if page.excerpt %}<meta name="description" content="{{ page.excerpt | strip_html }}">{% endif %}
 {% if page.tags %}<meta name="keywords" content="{{ page.tags | join: ', ' }}">{% endif %}
 {% if page.author %}

--- a/feed.xml
+++ b/feed.xml
@@ -4,7 +4,7 @@ sitemap: false
 
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
-<title type="text">{{ site.title }}</title>
+<title type="text">{{ site.title | strip_html }}</title>
 <generator uri="https://github.com/jekyll/jekyll">Jekyll</generator>
 <link rel="self" type="application/atom+xml" href="{{ site.url }}/feed.xml" />
 <link rel="alternate" type="text/html" href="{{ site.url }}" />


### PR DESCRIPTION
There is a html `<br>` element in the site title which is breaking the RSS feed - this Jekyll filter (strip_html) removes the html from site feed and page title.

You can validate the RSS feed is working ok on this site…

https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fdocslikecode.com%2Ffeed.xml

