### PR TITLE
Adds og:image to open graph section

### DIFF
--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -17,3 +17,4 @@
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.feature %}<meta name="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">{% endif %}


### PR DESCRIPTION
Refer to https://github.com/mmistakes/so-simple-theme/issues/68 for further explanation. Trying to fix an issue where, when you copy/paste an article URL into LinkedIn, the LinkedIn picks up the authors headshot instead of the featured image.